### PR TITLE
squid:S00116 - Field names should comply with a naming convention

### DIFF
--- a/app/src/main/java/com/vstechlab/testeasyfont/testeasyfont/MainActivity.java
+++ b/app/src/main/java/com/vstechlab/testeasyfont/testeasyfont/MainActivity.java
@@ -10,40 +10,40 @@ import com.vstechlab.easyfonts.EasyFonts;
 
 public class MainActivity extends AppCompatActivity {
     // Roboto
-    TextView tv_roboto_black;
-    TextView tv_roboto_black_italic;
-    TextView tv_roboto_bold;
-    TextView tv_roboto_bold_italic;
-    TextView tv_roboto_italic;
-    TextView tv_roboto_light;
-    TextView tv_roboto_light_italic;
-    TextView tv_roboto_medium;
-    TextView tv_roboto_medium_italic;
-    TextView tv_roboto_regular;
-    TextView tv_roboto_thin;
-    TextView tv_roboto_thin_italic;
+    TextView tvRobotoBlack;
+    TextView tvRobotoBlackItalic;
+    TextView tvRobotoBold;
+    TextView tvRobotoBoldItalic;
+    TextView tvRobotoItalic;
+    TextView tvRobotoLight;
+    TextView tvRobotoLightItalic;
+    TextView tvRobotoMedium;
+    TextView tvRobotoMediumItalic;
+    TextView tvRobotoRegular;
+    TextView tvRobotoThin;
+    TextView tvRobotoThinItalic;
     // Android Nation
-    TextView tv_android_nation;
-    TextView tv_android_nation_bold;
-    TextView tv_android_nation_italic;
+    TextView tvAndroidNation;
+    TextView tvAndroidNationBold;
+    TextView tvAndroidNationItalic;
     // Droid Robot
-    TextView tv_droid_robot;
+    TextView tvDroidRobot;
     // Droid Serif
-    TextView tv_droid_serif_bold;
-    TextView tv_droid_serif_bold_italic;
-    TextView tv_droid_serif_italic;
-    TextView tv_droid_serif_regular;
+    TextView tvDroidSerifBold;
+    TextView tvDroidSerifBoldItalic;
+    TextView tvDroidSerifItalic;
+    TextView tvDroidSerifRegular;
 
-    TextView tv_freedom;
+    TextView tvFreedom;
 
-    TextView tv_fun_raiser;
+    TextView tvFunRaiser;
 
-    TextView tv_green_avocado;
+    TextView tvGreenAvocado;
 
-    TextView tv_recognition;
+    TextView tvRecognition;
 
     // Walkway
-    TextView tv_walkway_black;
+    TextView tvWalkwayBlack;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -57,68 +57,68 @@ public class MainActivity extends AppCompatActivity {
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.menu_main, menu);
 
-        tv_roboto_black = (TextView) findViewById(R.id.tv_roboto_black);
-        tv_roboto_black_italic = (TextView) findViewById(R.id.tv_roboto_black_italic);
-        tv_roboto_bold = (TextView) findViewById(R.id.tv_roboto_bold);
-        tv_roboto_bold_italic = (TextView) findViewById(R.id.tv_roboto_bold_italic);
-        tv_roboto_italic = (TextView) findViewById(R.id.tv_roboto_italic);
-        tv_roboto_light = (TextView) findViewById(R.id.tv_roboto_light);
-        tv_roboto_light_italic = (TextView) findViewById(R.id.tv_roboto_light_italic);
-        tv_roboto_medium = (TextView) findViewById(R.id.tv_roboto_medium);
-        tv_roboto_medium_italic = (TextView) findViewById(R.id.tv_roboto_medium_italic);
-        tv_roboto_regular = (TextView) findViewById(R.id.tv_roboto_regular);
-        tv_roboto_thin = (TextView) findViewById(R.id.tv_roboto_thin);
-        tv_roboto_thin_italic = (TextView) findViewById(R.id.tv_roboto_thin_italic);
+        tvRobotoBlack = (TextView) findViewById(R.id.tv_roboto_black);
+        tvRobotoBlackItalic = (TextView) findViewById(R.id.tv_roboto_black_italic);
+        tvRobotoBold = (TextView) findViewById(R.id.tv_roboto_bold);
+        tvRobotoBoldItalic = (TextView) findViewById(R.id.tv_roboto_bold_italic);
+        tvRobotoItalic = (TextView) findViewById(R.id.tv_roboto_italic);
+        tvRobotoLight = (TextView) findViewById(R.id.tv_roboto_light);
+        tvRobotoLightItalic = (TextView) findViewById(R.id.tv_roboto_light_italic);
+        tvRobotoMedium = (TextView) findViewById(R.id.tv_roboto_medium);
+        tvRobotoMediumItalic = (TextView) findViewById(R.id.tv_roboto_medium_italic);
+        tvRobotoRegular = (TextView) findViewById(R.id.tv_roboto_regular);
+        tvRobotoThin = (TextView) findViewById(R.id.tv_roboto_thin);
+        tvRobotoThinItalic = (TextView) findViewById(R.id.tv_roboto_thin_italic);
 
-        tv_android_nation = (TextView) findViewById(R.id.tv_android_nation);
-        tv_android_nation_bold = (TextView) findViewById(R.id.tv_android_nation_bold);
-        tv_android_nation_italic = (TextView) findViewById(R.id.tv_android_nation_italic);
+        tvAndroidNation = (TextView) findViewById(R.id.tv_android_nation);
+        tvAndroidNationBold = (TextView) findViewById(R.id.tv_android_nation_bold);
+        tvAndroidNationItalic = (TextView) findViewById(R.id.tv_android_nation_italic);
 
-        tv_droid_robot = (TextView) findViewById(R.id.tv_droid_robot);
+        tvDroidRobot = (TextView) findViewById(R.id.tv_droid_robot);
 
-        tv_droid_serif_bold = (TextView) findViewById(R.id.tv_droid_serif_bold);
-        tv_droid_serif_bold_italic = (TextView) findViewById(R.id.tv_droid_serif_bold_italic);
-        tv_droid_serif_italic = (TextView) findViewById(R.id.tv_droid_serif_italic);
-        tv_droid_serif_regular = (TextView) findViewById(R.id.tv_droid_serif_regular);
+        tvDroidSerifBold = (TextView) findViewById(R.id.tv_droid_serif_bold);
+        tvDroidSerifBoldItalic = (TextView) findViewById(R.id.tv_droid_serif_bold_italic);
+        tvDroidSerifItalic = (TextView) findViewById(R.id.tv_droid_serif_italic);
+        tvDroidSerifRegular = (TextView) findViewById(R.id.tv_droid_serif_regular);
 
-        tv_freedom = (TextView) findViewById(R.id.tv_freedom);
-        tv_fun_raiser = (TextView) findViewById(R.id.tv_fun_raiser);
-        tv_green_avocado = (TextView) findViewById(R.id.tv_green_avocado);
-        tv_recognition = (TextView) findViewById(R.id.tv_recognition);
+        tvFreedom = (TextView) findViewById(R.id.tv_freedom);
+        tvFunRaiser = (TextView) findViewById(R.id.tv_fun_raiser);
+        tvGreenAvocado = (TextView) findViewById(R.id.tv_green_avocado);
+        tvRecognition = (TextView) findViewById(R.id.tv_recognition);
 
-        tv_walkway_black = (TextView) findViewById(R.id.tv_walkway_black);
+        tvWalkwayBlack = (TextView) findViewById(R.id.tv_walkway_black);
 
         // Set typeface
-        tv_roboto_black.setTypeface(EasyFonts.robotoBlack(this));
-        tv_roboto_black_italic.setTypeface(EasyFonts.robotoBlackItalic(this));
-        tv_roboto_bold.setTypeface(EasyFonts.robotoBold(this));
-        tv_roboto_bold_italic.setTypeface(EasyFonts.robotoBoldItalic(this));
-        tv_roboto_italic.setTypeface(EasyFonts.robotoItalic(this));
-        tv_roboto_light.setTypeface(EasyFonts.robotoLight(this));
-        tv_roboto_light_italic.setTypeface(EasyFonts.robotoLightItalic(this));
-        tv_roboto_medium.setTypeface(EasyFonts.robotoMedium(this));
-        tv_roboto_medium_italic.setTypeface(EasyFonts.robotoMediumItalic(this));
-        tv_roboto_regular.setTypeface(EasyFonts.robotoRegular(this));
-        tv_roboto_thin.setTypeface(EasyFonts.robotoThin(this));
-        tv_roboto_thin_italic.setTypeface(EasyFonts.robotoThinItalic(this));
+        tvRobotoBlack.setTypeface(EasyFonts.robotoBlack(this));
+        tvRobotoBlackItalic.setTypeface(EasyFonts.robotoBlackItalic(this));
+        tvRobotoBold.setTypeface(EasyFonts.robotoBold(this));
+        tvRobotoBoldItalic.setTypeface(EasyFonts.robotoBoldItalic(this));
+        tvRobotoItalic.setTypeface(EasyFonts.robotoItalic(this));
+        tvRobotoLight.setTypeface(EasyFonts.robotoLight(this));
+        tvRobotoLightItalic.setTypeface(EasyFonts.robotoLightItalic(this));
+        tvRobotoMedium.setTypeface(EasyFonts.robotoMedium(this));
+        tvRobotoMediumItalic.setTypeface(EasyFonts.robotoMediumItalic(this));
+        tvRobotoRegular.setTypeface(EasyFonts.robotoRegular(this));
+        tvRobotoThin.setTypeface(EasyFonts.robotoThin(this));
+        tvRobotoThinItalic.setTypeface(EasyFonts.robotoThinItalic(this));
 
-        tv_android_nation.setTypeface(EasyFonts.androidNation(this));
-        tv_android_nation_bold.setTypeface(EasyFonts.androidNationBold(this));
-        tv_android_nation_italic.setTypeface(EasyFonts.androidNationItalic(this));
+        tvAndroidNation.setTypeface(EasyFonts.androidNation(this));
+        tvAndroidNationBold.setTypeface(EasyFonts.androidNationBold(this));
+        tvAndroidNationItalic.setTypeface(EasyFonts.androidNationItalic(this));
 
-        tv_droid_robot.setTypeface(EasyFonts.droidRobot(this));
+        tvDroidRobot.setTypeface(EasyFonts.droidRobot(this));
 
-        tv_droid_serif_bold.setTypeface(EasyFonts.droidSerifBold(this));
-        tv_droid_serif_bold_italic.setTypeface(EasyFonts.droidSerifBoldItalic(this));
-        tv_droid_serif_italic.setTypeface(EasyFonts.droidSerifItalic(this));
-        tv_droid_serif_regular.setTypeface(EasyFonts.droidSerifRegular(this));
+        tvDroidSerifBold.setTypeface(EasyFonts.droidSerifBold(this));
+        tvDroidSerifBoldItalic.setTypeface(EasyFonts.droidSerifBoldItalic(this));
+        tvDroidSerifItalic.setTypeface(EasyFonts.droidSerifItalic(this));
+        tvDroidSerifRegular.setTypeface(EasyFonts.droidSerifRegular(this));
 
-        tv_freedom.setTypeface(EasyFonts.freedom(this));
-        tv_fun_raiser.setTypeface(EasyFonts.funRaiser(this));
-        tv_green_avocado.setTypeface(EasyFonts.greenAvocado(this));
-        tv_recognition.setTypeface(EasyFonts.recognition(this));
+        tvFreedom.setTypeface(EasyFonts.freedom(this));
+        tvFunRaiser.setTypeface(EasyFonts.funRaiser(this));
+        tvGreenAvocado.setTypeface(EasyFonts.greenAvocado(this));
+        tvRecognition.setTypeface(EasyFonts.recognition(this));
 
-        tv_walkway_black.setTypeface(EasyFonts.walkwayBlack(this));
+        tvWalkwayBlack.setTypeface(EasyFonts.walkwayBlack(this));
 
         return true;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S00116 - Field names should comply with a naming convention

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S00116

Please let me know if you have any questions.

M-Ezzat
